### PR TITLE
more response info introduced to Client + minor fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Changelog
 *********
 
+0.7 (2014-10-03)
+==================
+ * more response info introduced to Client: resp_headers, resp_code, raw_content, real_url
+ * return value type for opener.readpage changed and is not backward compatible;
+   this doesn't impact opener.Client
+ * useless class BaseCaptchaAwareClient removed
+ * unused imports removed
+ * minor issues with DELAY var fixed
+
 0.6.6 (2014-09-19)
 ==================
  * exceptions handling issue fixed

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,11 +4,14 @@ Changelog
 0.7 (2014-10-03)
 ==================
  * more response info introduced to Client: resp_headers, resp_code, raw_content, real_url
- * return value type for opener.readpage changed and is not backward compatible;
+ * opener.readpage changed and is not backward compatible:
+    - return value type changed
+    - needURL parameter removed from opener.readpage
    this doesn't impact opener.Client
  * useless class BaseCaptchaAwareClient removed
  * unused imports removed
  * minor issues with DELAY var fixed
+ * opener.Client does not use X-Forwarded-For by default, which is also not backward-compatible
 
 0.6.6 (2014-09-19)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(*rnames):
 
 setup(
     name='sterch.scrapingtools',
-    version='0.6.6',
+    version='0.7',
     url='http://sterch.net',
     license='ZPL',
     description='Library for building scrapers',

--- a/src/sterch/scrapingtools/__init__.py
+++ b/src/sterch/scrapingtools/__init__.py
@@ -1,11 +1,11 @@
 ### -*- coding: utf-8 -*- #############################################
 # Developed by Maksym Polshcha (maxp@sterch.net)
-# All right reserved, 2012, 2013
+# All right reserved, 2012, 2013, 2014
 #######################################################################
 
 # Make it a Python package
 from courts import is_plaintiff, is_defendant, is_attorney, extract_description, extract_date, extract_money, is_john_doe, is_valid_attorney, SequenceState
-from opener import createOpener, readpage, Client, BaseCaptchaAwareClient, clone_client
+from opener import createOpener, readpage, Client, clone_client
 from output import start_chunked_stdout, stop_chunked_stdout
 from synclist import SyncList, DuplicateValueError
 from text import replace_html_entities, striptags, normalize, tofilename, parse_fullname, parse_fulladdress


### PR DESCRIPTION
- more response info introduced to Client: resp_headers, resp_code, raw_content, real_url
  - return value type for opener.readpage changed and is not backward compatible;
    this doesn't impact opener.Client
  - useless class BaseCaptchaAwareClient removed
  - unused imports removed
  - minor issues with DELAY var fixed
